### PR TITLE
fix: prevent LOAS calculation attempt without administrative request

### DIFF
--- a/src/modules/GetInformationFromSapiensForPicaPau/BuscarImpedimentos/BuscarImpedimentosUseCase.ts
+++ b/src/modules/GetInformationFromSapiensForPicaPau/BuscarImpedimentos/BuscarImpedimentosUseCase.ts
@@ -179,6 +179,10 @@ export class BuscarImpedimentosUseCase {
 
         if (!informacoesProcesso.dossieSocialInfo) {
             impedimentoCapa.push("CADÚNICO");
+        } else if (
+            impedimentosBusca.objImpedimentos.requerimento
+        ) {
+            console.warn("AUSÊNCIA DE REQUERIMENTO ADMINISTRATIVO -> NÃO CALCULAR A RENDA");
         } else {
             grupoFamiliar = await getGrupoFamiliarCpfs(
                 informacoesProcesso.tarefaPastaID,


### PR DESCRIPTION
Added validation to block calculation processes when there is no administrative request present, ensuring data integrity and preventing errors.